### PR TITLE
去除结尾的"<|im_end|>"

### DIFF
--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -97,6 +97,10 @@ namespace SakuraTranslator
             var startIndex = responseText.IndexOf("\"content\":") + 10;
             var endIndex = responseText.IndexOf(",", startIndex);
             var translatedLine = responseText.Substring(startIndex, endIndex - startIndex).Trim('\"', ' ', '\r', '\n');
+            if (translatedLine.EndsWith("<|im_end|>"))
+            {
+                translatedLine = translatedLine.Substring(0, translatedLine.Length - "<|im_end|>".Length);
+            }
 
             // 将翻译后的行添加到StringBuilder
             translatedTextBuilder.AppendLine(translatedLine);


### PR DESCRIPTION
高版本llama.cpp在调用/completion时可能会在末尾产生多余的"<|im_end|>"
下图为llama.cpp-b1892-cu12.2，sakura-7b-lnovel-v0.9-Q5_K_M模型在Windows下产生的输出
使用llama.cpp-b1848时，不会产生多余的"<|im_end|>"
不确定其他平台或者13B模型会不会出现相同情况
![image](https://github.com/fkiliver/SakuraTranslator/assets/21260494/e9665dd5-a49d-4b85-844c-384c01690daf)
