### PR TITLE
添加v0.10pre0的字典支持

### DIFF
--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -6,8 +6,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
+
+[assembly: AssemblyVersion("0.2.3")]
+[assembly: AssemblyFileVersion("0.2.3")]
 
 namespace SakuraTranslator
 {

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -1,6 +1,10 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
@@ -20,11 +24,49 @@ namespace SakuraTranslator
         // params
         private string _endpoint;
         private string _apiType;
+        private bool _useDict;
+        private string _dictMode;
+        private Dictionary<string, string> _dict;
+
+        // local var
+        private string _fullDictStr;
 
         public void Initialize(IInitializationContext context)
         {
             _endpoint = context.GetOrCreateSetting<string>("Sakura", "Endpoint", "http://127.0.0.1:8080/completion");
             _apiType = context.GetOrCreateSetting<string>("Sakura", "ApiType", string.Empty);
+            if (!bool.TryParse(context.GetOrCreateSetting<string>("Sakura", "UseDict", string.Empty), out _useDict))
+            {
+                _useDict = false;
+            }
+            _dictMode = context.GetOrCreateSetting<string>("Sakura", "DictMode", "Full");
+            var dictStr = context.GetOrCreateSetting<string>("Sakura", "Dict", string.Empty);
+            if (!string.IsNullOrEmpty(dictStr))
+            {
+                try
+                {
+                    _dict = new Dictionary<string, string>();
+                    JObject dictJObj = JsonConvert.DeserializeObject(dictStr) as JObject;
+                    foreach (var item in dictJObj)
+                    {
+                        _dict.Add(item.Key, item.Value.ToString());
+                    }
+                    if (_dict.Count == 0)
+                    {
+                        _useDict = false;
+                        _fullDictStr = string.Empty;
+                    }
+                    else
+                    {
+                        _fullDictStr = string.Join("\n", _dict.Select(x => $"{x.Key}->{x.Value}").ToArray());
+                    }
+                }
+                catch
+                {
+                    _useDict = false;
+                    _fullDictStr = string.Empty;
+                }
+            }
         }
 
         public IEnumerator Translate(ITranslationContext context)
@@ -118,9 +160,67 @@ namespace SakuraTranslator
             }
             else if (_apiType == "OpenAI")
             {
-                json = $"{{" +
-                       $"\"model\": \"sukinishiro\"," +
-                       $"\"messages\": [" +
+                json = MakeOpenAIPrompt(line);
+            }
+            else
+            {
+                json = $"{{\"frequency_penalty\": 0.2, \"n_predict\": 1000, \"prompt\": \"<reserved_106>将下面的日文文本翻译成中文：{line}<reserved_107>\", \"repeat_penalty\": 1, \"temperature\": 0.1, \"top_k\": 40, \"top_p\": 0.3}}";
+            }
+
+            return json;
+        }
+
+        private string MakeOpenAIPrompt(string line)
+        {
+            string messagesStr = string.Empty;
+            if (_useDict)
+            {
+                var messages = new List<PromptMessage>
+                {
+                    new PromptMessage
+                    {
+                        role = "system",
+                        content = "你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。"
+                    }
+                };
+                string dictStr;
+                if (_dictMode == "Full")
+                {
+                    dictStr = _fullDictStr;
+                }
+                else
+                {
+                    var usedDict = _dict.Where(x => line.Contains(x.Key));
+                    if (usedDict.Count() > 0)
+                    {
+                        dictStr = string.Join("\n", usedDict.Select(x => $"{x.Key}->{x.Value}").ToArray());
+                    }
+                    else
+                    {
+                        dictStr = string.Empty;
+                    }
+                }
+                if (string.IsNullOrEmpty(dictStr))
+                {
+                    messages.Add(new PromptMessage
+                    {
+                        role = "user",
+                        content = $"将下面的日文文本翻译成中文：{line}"
+                    });
+                }
+                else
+                {
+                    messages.Add(new PromptMessage
+                    {
+                        role = "user",
+                        content = $"根据以下术语表：\n{dictStr}\n将下面的日文文本根据上述术语表的对应关系和注释翻译成中文：{line}"
+                    });
+                }
+                messagesStr = JsonConvert.SerializeObject(messages, Formatting.None);
+            }
+            else
+            {
+                messagesStr = "[" +
                        $"{{" +
                        $"\"role\": \"system\"," +
                        $"\"content\": \"你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，不擅自添加原文中没有的代词。\"" +
@@ -129,7 +229,13 @@ namespace SakuraTranslator
                                 $"\"role\": \"user\"," +
                        $"\"content\": \"将下面的日文文本翻译成中文：{line}\"" +
                        $"}}" +
-                       $"]," +
+                       $"]";
+            }
+            return $"{{" +
+                       $"\"model\": \"sukinishiro\"," +
+                       $"\"messages\": " +
+                       messagesStr +
+                       $"," +
                        $"\"temperature\": 0.1," +
                        $"\"top_p\": 0.3," +
                        $"\"max_tokens\": 1000," +
@@ -139,13 +245,12 @@ namespace SakuraTranslator
                        $"\"um_beams\": 1," +
                        $"\"repetition_penalty\": 1.0" +
                        $"}}";
-            }
-            else
-            {
-                json = $"{{\"frequency_penalty\": 0.2, \"n_predict\": 1000, \"prompt\": \"<reserved_106>将下面的日文文本翻译成中文：{line}<reserved_107>\", \"repeat_penalty\": 1, \"temperature\": 0.1, \"top_k\": 40, \"top_p\": 0.3}}";
-            }
+        }
 
-            return json;
+        class PromptMessage
+        {
+            public string role { get; set; }
+            public string content { get; set; }
         }
     }
 }

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -220,7 +220,7 @@ namespace SakuraTranslator
                         content = $"根据以下术语表：\n{dictStr}\n将下面的日文文本根据上述术语表的对应关系和注释翻译成中文：{line}"
                     });
                 }
-                messagesStr = JsonConvert.SerializeObject(messages, Formatting.None);
+                messagesStr = SerializePromptMessages(messages);
             }
             else
             {
@@ -249,6 +249,15 @@ namespace SakuraTranslator
                        $"\"um_beams\": 1," +
                        $"\"repetition_penalty\": 1.0" +
                        $"}}";
+        }
+
+        private string SerializePromptMessages(List<PromptMessage> messages)
+        {
+            string result = "[";
+            result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.role}\",\"content\":\"{x.content}\"}}").ToArray());
+            result += "]";
+            result = result.Replace("\n", "\\n");
+            return result;
         }
 
         class PromptMessage

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -183,8 +183,8 @@ namespace SakuraTranslator
                 {
                     new PromptMessage
                     {
-                        role = "system",
-                        content = "你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。"
+                        Role = "system",
+                        Content = "你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。"
                     }
                 };
                 string dictStr;
@@ -208,16 +208,16 @@ namespace SakuraTranslator
                 {
                     messages.Add(new PromptMessage
                     {
-                        role = "user",
-                        content = $"将下面的日文文本翻译成中文：{line}"
+                        Role = "user",
+                        Content = $"将下面的日文文本翻译成中文：{line}"
                     });
                 }
                 else
                 {
                     messages.Add(new PromptMessage
                     {
-                        role = "user",
-                        content = $"根据以下术语表：\n{dictStr}\n将下面的日文文本根据上述术语表的对应关系和注释翻译成中文：{line}"
+                        Role = "user",
+                        Content = $"根据以下术语表：\n{dictStr}\n将下面的日文文本根据上述术语表的对应关系和注释翻译成中文：{line}"
                     });
                 }
                 messagesStr = SerializePromptMessages(messages);
@@ -254,8 +254,8 @@ namespace SakuraTranslator
         private string SerializePromptMessages(List<PromptMessage> messages)
         {
             string result = "[";
-            result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.role}\"," +
-                $"\"content\":\"{EscapeJsonString(x.content)}\"}}").ToArray());
+            result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.Role}\"," +
+                $"\"content\":\"{EscapeJsonString(x.Content)}\"}}").ToArray());
             result += "]";
             return result;
         }
@@ -276,8 +276,8 @@ namespace SakuraTranslator
 
         class PromptMessage
         {
-            public string role { get; set; }
-            public string content { get; set; }
+            public string Role { get; set; }
+            public string Content { get; set; }
         }
     }
 }

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -254,10 +254,24 @@ namespace SakuraTranslator
         private string SerializePromptMessages(List<PromptMessage> messages)
         {
             string result = "[";
-            result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.role}\",\"content\":\"{x.content}\"}}").ToArray());
+            result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.role}\"," +
+                $"\"content\":\"{EscapeJsonString(x.content)}\"}}").ToArray());
             result += "]";
-            result = result.Replace("\n", "\\n");
             return result;
+        }
+
+        private string EscapeJsonString(string str)
+        {
+            return str
+                .Replace("\\", "\\\\")
+                .Replace("/", "\\/")
+                .Replace("\b", "\\b")
+                .Replace("\f", "\\f")
+                .Replace("\n", "\\n")
+                .Replace("\r", "\\r")
+                .Replace("\t", "\\t")
+                .Replace("\v", "\\v")
+                .Replace("\"", "\\\"");
         }
 
         class PromptMessage


### PR DESCRIPTION
添加文件版本（0.2.3）
添加配置（仅在`OpenAI`模式下生效）

- `UseDict`默认为空字符串
- `DictMode`默认为`Full`
- `Dict`默认为空字符串

其中

 - `UseDict`为false时是老的OpenAI Prompt
 - `DictMode`为`Full`时传递整个字典，为`Partial`或其他时，传递当前翻译句子包含的字典部分
 - `Dict`为json编码的字符串，格式同MTool，为`{"k1":"v1","k2":"v2"}`，暂未发现SakuraLLM官方示例中给的字典注释有什么作用

llama.cpp-b2355，sakura-13b-qwen2beta-v0.10pre0-Q6_K.gguf，Windows和Linux下测试
理论上高版本llama.cpp和Kaggle都能用，不过我未测试Kaggle
配置：
```
[Sakura]
Endpoint=http://127.0.0.1:5000/v1/chat/completions
ApiType=OpenAI
UseDict=True
DictMode=Full
Dict={"たちばな":"橘","橘":"橘","あやの":"绫乃","綾乃":"绫乃"}
```