### PR TITLE
去除结尾多余句号，添加并发配置

### DIFF
--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -21,13 +21,14 @@ namespace SakuraTranslator
 
         public string FriendlyName => "Sakura Translator";
 
-        public int MaxConcurrency => 1;
+        public int MaxConcurrency => _maxConcurrency;
 
         public int MaxTranslationsPerRequest => 1;
 
         // params
         private string _endpoint;
         private string _apiType;
+        private int _maxConcurrency;
         private bool _useDict;
         private string _dictMode;
         private Dictionary<string, string> _dict;
@@ -39,6 +40,10 @@ namespace SakuraTranslator
         {
             _endpoint = context.GetOrCreateSetting<string>("Sakura", "Endpoint", "http://127.0.0.1:8080/completion");
             _apiType = context.GetOrCreateSetting<string>("Sakura", "ApiType", string.Empty);
+            if (!int.TryParse(context.GetOrCreateSetting<string>("Sakura", "MaxConcurrency", "1"), out _maxConcurrency))
+            {
+                _maxConcurrency = 1;
+            }
             if (!bool.TryParse(context.GetOrCreateSetting<string>("Sakura", "UseDict", string.Empty), out _useDict))
             {
                 _useDict = false;

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -147,6 +147,14 @@ namespace SakuraTranslator
             {
                 translatedLine = translatedLine.Substring(0, translatedLine.Length - "<|im_end|>".Length);
             }
+            if (translatedLine.EndsWith("。") && !line.Trim().EndsWith("。"))
+            {
+                translatedLine = translatedLine.Substring(0, translatedLine.Length - "。".Length);
+            }
+            if (translatedLine.EndsWith("。」") && !line.Trim().EndsWith("。」"))
+            {
+                translatedLine = translatedLine.Substring(0, translatedLine.Length - "。」".Length) + "」";
+            }
 
             // 将翻译后的行添加到StringBuilder
             translatedTextBuilder.AppendLine(translatedLine);

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -10,8 +10,8 @@ using System.Reflection;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 
-[assembly: AssemblyVersion("0.2.3")]
-[assembly: AssemblyFileVersion("0.2.3")]
+[assembly: AssemblyVersion("0.3.1")]
+[assembly: AssemblyFileVersion("0.3.1")]
 
 namespace SakuraTranslator
 {


### PR DESCRIPTION
当原句结尾不包含句号，翻译完最后为句号时，去除翻译文本的句号（常见于短句/短语）
添加并发参数MaxConcurrency，单卡多线程总体翻译速度比单线程高（3090，1线程约50t/s，5线程约5x35t/s）