### PR TITLE
Sakura 32B v0.10pre1

### DIFF
--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -226,6 +226,10 @@ namespace SakuraTranslator
             {
                 json = MakeOpenAIPrompt(line);
             }
+            else if (_apiType == "Sakura32bV010")
+            {
+                json = MakeSakura32bV010Prompt(line);
+            }
             else
             {
                 json = $"{{\"frequency_penalty\": 0.2, \"n_predict\": 1000, \"prompt\": \"<reserved_106>将下面的日文文本翻译成中文：{line}<reserved_107>\", \"repeat_penalty\": 1, \"temperature\": 0.1, \"top_k\": 40, \"top_p\": 0.3}}";
@@ -296,6 +300,63 @@ namespace SakuraTranslator
                        $"}}" +
                        $"]";
             }
+            return $"{{" +
+                       $"\"model\": \"sukinishiro\"," +
+                       $"\"messages\": " +
+                       messagesStr +
+                       $"," +
+                       $"\"temperature\": 0.1," +
+                       $"\"top_p\": 0.3," +
+                       $"\"max_tokens\": 1000," +
+                       $"\"frequency_penalty\": 0.2," +
+                       $"\"do_sample\": false," +
+                       $"\"top_k\": 40," +
+                       $"\"um_beams\": 1," +
+                       $"\"repetition_penalty\": 1.0" +
+                       $"}}";
+        }
+
+        private string MakeSakura32bV010Prompt(string line)
+        {
+            string messagesStr = string.Empty;
+            var messages = new List<PromptMessage>
+                {
+                    new PromptMessage
+                    {
+                        Role = "system",
+                        Content = "你是一个轻小说翻译模型，可以流畅通顺地使用给定的术语表以日本轻小说的风格将日文翻译成简体中文，并联系上下文正确使用人称代词，注意不要混淆使役态和被动态的主语和宾语，不要擅自添加原文中没有的代词，也不要擅自增加或减少换行。"
+                    }
+                };
+            string dictStr;
+            if (_useDict == false)
+            {
+                dictStr = string.Empty;
+            }
+            else if (_dictMode == "Full")
+            {
+                dictStr = _fullDictStr;
+            }
+            else
+            {
+                var usedDict = _dict.Where(x => line.Contains(x.Key));
+                if (usedDict.Count() > 0)
+                {
+                    var dictStrings = GetDictStringList(usedDict);
+                    dictStr = string.Join("\n", dictStrings.ToArray());
+                }
+                else
+                {
+                    dictStr = string.Empty;
+                }
+            }
+            messages.Add(new PromptMessage
+            {
+                Role = "user",
+                Content = $"根据以下术语表（可以为空）：\n{dictStr}\n\n" +
+                          $"将下面的日文文本根据上述术语表的对应关系和备注翻译成中文：{line}"
+            });
+            messagesStr = SerializePromptMessages(messages);
+
             return $"{{" +
                        $"\"model\": \"sukinishiro\"," +
                        $"\"messages\": " +

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -44,7 +44,7 @@ namespace SakuraTranslator
             {
                 _maxConcurrency = 1;
             }
-            if (_maxConcurrency > 2)
+            if (_maxConcurrency > ServicePointManager.DefaultConnectionLimit)
             {
                 ServicePointManager.DefaultConnectionLimit = _maxConcurrency;
             }

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -10,8 +10,8 @@ using System.Reflection;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 
-[assembly: AssemblyVersion("0.3.2")]
-[assembly: AssemblyFileVersion("0.3.2")]
+[assembly: AssemblyVersion("0.3.3")]
+[assembly: AssemblyFileVersion("0.3.3")]
 
 namespace SakuraTranslator
 {


### PR DESCRIPTION
仅经过初步测试

初步Sakura 32B v0.10pre1支持，ApiType为"Sakura32bV010"
32B目前对行内格式控制字符（字符串"\\\\n"等，如"测试\\\\n测试"）支持有问题，如果这类情况很多，后续可以考虑按照"\\\\n"再进行切分
代码混乱，等v0.10正式版出了可以考虑重构

### 字典
- 字典格式{"src":["dst","info"]}，发给sakura的字典为"src->dst #info"
- 其中info没有可以写成{"src":["dst"]}或者{"src":"dst"}，此时发给sakura的字典为"src->dst"

![image](https://github.com/fkiliver/SakuraTranslator/assets/21260494/f1e61d5d-3326-463f-9c1b-20139c3165c6)
