### PR TITLE
v0.3.4：添加Sakura V1.0、GalTransl V2.6支持

### DIFF
--- a/SakuraTranslator/SakuraTranslator.csproj
+++ b/SakuraTranslator/SakuraTranslator.csproj
@@ -55,6 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="TranslationModel.cs" />
     <Compile Include="SakuraTranslatorEndpoint.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Reflection;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
+using XUnity.AutoTranslator.Plugin.Core.Utilities;
 
 [assembly: AssemblyVersion("0.3.4")]
 [assembly: AssemblyFileVersion("0.3.4")]
@@ -219,7 +220,7 @@ namespace SakuraTranslator
             {
                 json = $"{{\"prompt\":\"<|im_start|>system\\n你是一个轻小说翻译模型，可以流畅通顺地以日本轻小说的风格将日文翻译成简体中文，" +
                 $"并联系上下文正确使用人称代词，不擅自添加原文中没有的代词。<|im_end|>\\n<|im_start|>user\\n将下面的日文文本翻译成中文：" +
-                $"{EscapeJsonString(line)}<|im_end|>\\n<|im_start|>assistant\\n\",\"n_predict\":1024,\"temperature\":0.1,\"top_p\":0.3,\"repeat_penalty\":1," +
+                $"{JsonHelper.Escape(line)}<|im_end|>\\n<|im_start|>assistant\\n\",\"n_predict\":1024,\"temperature\":0.1,\"top_p\":0.3,\"repeat_penalty\":1," +
                 $"\"frequency_penalty\":0.2,\"top_k\":40,\"seed\":-1}}";
             }
             else if (_apiType == "OpenAI")
@@ -232,7 +233,7 @@ namespace SakuraTranslator
             }
             else
             {
-                json = $"{{\"frequency_penalty\": 0.2, \"n_predict\": 1000, \"prompt\": \"<reserved_106>将下面的日文文本翻译成中文：{EscapeJsonString(line)}<reserved_107>\", \"repeat_penalty\": 1, \"temperature\": 0.1, \"top_k\": 40, \"top_p\": 0.3}}";
+                json = $"{{\"frequency_penalty\": 0.2, \"n_predict\": 1000, \"prompt\": \"<reserved_106>将下面的日文文本翻译成中文：{JsonHelper.Escape(line)}<reserved_107>\", \"repeat_penalty\": 1, \"temperature\": 0.1, \"top_k\": 40, \"top_p\": 0.3}}";
             }
 
             return json;
@@ -296,7 +297,7 @@ namespace SakuraTranslator
                        $"}}," +
                                 $"{{" +
                                 $"\"role\": \"user\"," +
-                       $"\"content\": \"将下面的日文文本翻译成中文：{EscapeJsonString(line)}\"" +
+                       $"\"content\": \"将下面的日文文本翻译成中文：{JsonHelper.Escape(line)}\"" +
                        $"}}" +
                        $"]";
             }
@@ -377,23 +378,9 @@ namespace SakuraTranslator
         {
             string result = "[";
             result += string.Join(",", messages.Select(x => $"{{\"role\":\"{x.Role}\"," +
-                $"\"content\":\"{EscapeJsonString(x.Content)}\"}}").ToArray());
+                $"\"content\":\"{JsonHelper.Escape(x.Content)}\"}}").ToArray());
             result += "]";
             return result;
-        }
-
-        private string EscapeJsonString(string str)
-        {
-            return str
-                .Replace("\\", "\\\\")
-                .Replace("/", "\\/")
-                .Replace("\b", "\\b")
-                .Replace("\f", "\\f")
-                .Replace("\n", "\\n")
-                .Replace("\r", "\\r")
-                .Replace("\t", "\\t")
-                .Replace("\v", "\\v")
-                .Replace("\"", "\\\"");
         }
 
         class PromptMessage

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -53,7 +53,7 @@ namespace SakuraTranslator
             {
                 ServicePointManager.DefaultConnectionLimit = _maxConcurrency;
             }
-            if (!bool.TryParse(context.GetOrCreateSetting<string>("Sakura", "UseDict", string.Empty), out _useDict))
+            if (!bool.TryParse(context.GetOrCreateSetting<string>("Sakura", "UseDict", "False"), out _useDict))
             {
                 _useDict = false;
             }

--- a/SakuraTranslator/SakuraTranslatorEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslatorEndpoint.cs
@@ -10,8 +10,8 @@ using System.Reflection;
 using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 
-[assembly: AssemblyVersion("0.3.3")]
-[assembly: AssemblyFileVersion("0.3.3")]
+[assembly: AssemblyVersion("0.3.4")]
+[assembly: AssemblyFileVersion("0.3.4")]
 
 namespace SakuraTranslator
 {

--- a/SakuraTranslator/TranslationModel.cs
+++ b/SakuraTranslator/TranslationModel.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using XUnity.AutoTranslator.Plugin.Core.Endpoints;
+
+namespace SakuraTranslator
+{
+    public partial class SakuraTranslatorEndpoint : ITranslateEndpoint
+    {
+        private enum TranslationModel
+        {
+            SakuraV0_8,
+            SakuraV0_9,
+            SakuraV0_10,
+            SakuraV1_0,
+            Sakura32bV0_10,
+            GalTranslV2_6
+        }
+
+        private static TranslationModel GetTranslationModel(string modelName, string modelVersion)
+        {
+            switch (modelName.ToLower())
+            {
+                case "sakura":
+                    switch (modelVersion)
+                    {
+                        case "0.8": return TranslationModel.SakuraV0_8;
+                        case "0.9": return TranslationModel.SakuraV0_9;
+                        case "0.10": return TranslationModel.SakuraV0_10;
+                        case "1.0": return TranslationModel.SakuraV1_0;
+                        default: return TranslationModel.SakuraV1_0;
+                    }
+                case "sakura32b":
+                    switch (modelVersion)
+                    {
+                        case "0.10": return TranslationModel.Sakura32bV0_10;
+                        default: return TranslationModel.Sakura32bV0_10;
+                    }
+                case "galtransl":
+                    switch (modelVersion)
+                    {
+                        case "2.6": return TranslationModel.GalTranslV2_6;
+                        default: return TranslationModel.GalTranslV2_6;
+                    }
+                default:
+                    return TranslationModel.SakuraV1_0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 完整配置示例
```
[Sakura]
Endpoint=http://192.168.199.55:5000/v1/chat/completions
ModelName=Sakura
ModelVersion=1.0
MaxConcurrency=2
UseDict=True
DictMode=Full
Dict={"アイリス":["艾莉斯","女"]}
```

### 支持的模型及对应关系
将原`ApiType`拆成`ModelName`和`ModelVersion`，对应关系如下表，其中`*`表示没有匹配时的默认值
| ModelName  | ModelVersion | TranslationModel       |
|------------|--------------|------------------------|
| Sakura     | 0.8          | Sakura 0.8             |
| Sakura     | 0.9          | Sakura/Sakura32B 0.9             |
| Sakura     | 0.10         | Sakura 0.10pre1            |
| Sakura     | 1.0          | Sakura 1.0             |
| Sakura     | *            | Sakura 1.0 (默认)      |
| Sakura32B  | 0.10         | Sakura32B 0.10         |
| Sakura32B  | *            | Sakura32B 0.10 (默认)  |
| GalTransl  | 2.6          | GalTransl 2.6          |
| GalTransl  | *            | GalTransl 2.6 (默认)   |
| *          | *            | Sakura 1.0 (默认)      |

此外删除了`top_k`参数，修改了拼写错误`um_beams`
模型相关默认值设置为Sakura 1.0

### 字典
#### 字典配置项
- `UseDict`默认为`False`，设置为`True`才会启用字典功能
- `DictMode`默认为`Full`，为`Full`时传递整个字典，为`Partial`或其他时，传递当前翻译句子包含的字典部分
- `Dict`默认为空字符串
#### 字典配置（Dict）
- 必须为空或合法的Json格式，解析失败将会视为空
- 字典格式`{"src":["dst","info"]}`，发给sakura的字典为`src->dst #info`
- 其中`info`没有可以写成`{"src":["dst"]}`或者`{"src":"dst"}`，此时发给sakura的字典为`src->dst`
- 示例：`{"たちばな":"橘","橘":["橘"],"あやの":["绫乃","女"],"綾乃":["绫乃","女"]}`

### 存疑
- `frequency_penalty`目前设置为`0.2`，暂时没有加入退化检测
- 我在写DeekSeek翻译插件时，发现用`ReadToEnd`读取`responseStream`时可能会导致游戏卡顿（即读取`HttpWebRequest`时，`asyncResult.IsCompleted`为真时，读取仍有可能阻塞，其中DeekSeek API的流式传输已关闭），我个人后续丢到线程池解决了，`llama.cpp`的服务端暂时没发现有问题
- `Id`和生成插件名称可考虑改为`SakuraTranslate`，官方插件均已`Translate`结尾