### PR TITLE
更新GalTransl prompt、修复Sakura 0.8/0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # 介绍
 这是一个基于XUnity.AutoTranslator和Sakura模型的Unity游戏本地翻译器,能够提供高质量离线日文翻译  
-建议使用[Galtransl-v2.6翻译模型](https://github.com/SakuraLLM/Sakura-13B-Galgame)，当前支持版本为Sakura v0.8/v0.9/v0.10/v1.0,GalTrans2.6
+建议使用[Galtransl-v2.6翻译模型](https://huggingface.co/SakuraLLM/GalTransl-7B-v2.6)，当前支持版本为Sakura v0.8/v0.9/v0.10/v1.0,GalTrans2.6
 
 ## TODO
 - [ ] 添加退化检测（搁置，较新的模型基本不需要）
@@ -60,7 +60,7 @@ ModelName=Sakura
 ModelVersion=1.0
 MaxConcurrency=2
 UseDict=True
-DictMode=Full
+DictMode=Partial
 Dict={"アイリス":["艾莉斯","女"]}
 ```
 
@@ -69,8 +69,8 @@ Dict={"アイリス":["艾莉斯","女"]}
 | ModelName  | ModelVersion | TranslationModel       |
 |------------|--------------|------------------------|
 | Sakura     | 0.8          | Sakura 0.8             |
-| Sakura     | 0.9          | Sakura/Sakura32B 0.9*             |
-| Sakura     | 0.10         | Sakura 0.10pre1            |
+| Sakura     | 0.9          | Sakura 7B/14B/32B 0.9  |
+| Sakura     | 0.10         | Sakura 0.10            |
 | Sakura     | 1.0          | Sakura 1.0             |
 | Sakura     | *            | Sakura 1.0 (默认)      |
 | Sakura32B  | 0.10         | Sakura32B 0.10         |
@@ -79,7 +79,9 @@ Dict={"アイリス":["艾莉斯","女"]}
 | GalTransl  | *            | GalTransl 2.6 (默认)   |
 | *          | *            | Sakura 1.0 (默认)      |
 
-模型相关默认值设置为Sakura 1.0，注意Sakura32B 0.9*需将`ModelName`设置为`Sakura`
+模型相关默认值设置为Sakura 1.0，注意Sakura 7B/14B/32B 0.9系列模型需将`ModelName`设置为`Sakura`  
+其中Sakura 0.8/0.9模型需要将`Endpoint`设置为completion api（例：`http://127.0.0.1:8080/completion`）  
+Sakura 0.10/1.0和GalTransl模型需要将`Endpoint`设置为chat completions api（例：`http://127.0.0.1:8080/v1/chat/completions`）  
 
 ### 字典
 #### 字典配置项

--- a/SakuraTranslator/SakuraTranslate.csproj
+++ b/SakuraTranslator/SakuraTranslate.csproj
@@ -55,6 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SakuraUtil.cs" />
     <Compile Include="TranslationModel.cs" />
     <Compile Include="SakuraTranslateEndpoint.cs" />
   </ItemGroup>

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -47,7 +47,7 @@ namespace SakuraTranslate
             _modelVersion = context.GetOrCreateSetting<string>("Sakura", "ModelVersion", "1.0");
             _modelType = GetTranslationModel(_modelName, _modelVersion);
             if (!int.TryParse(context.GetOrCreateSetting<string>("Sakura", "MaxConcurrency", "1"), out _maxConcurrency))
-            { 
+            {
                 _maxConcurrency = 1;
             }
             if (_maxConcurrency > ServicePointManager.DefaultConnectionLimit)
@@ -178,7 +178,15 @@ namespace SakuraTranslate
             //var translatedText = responseText.Substring(startIndex, endIndex - startIndex);
 
             JObject jsonResponse = JObject.Parse(responseText);
-            string translatedText = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString();
+            string translatedText;
+            if (IsOpenAIEndpoint(_modelType))
+            {
+                translatedText = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString();
+            }
+            else
+            {
+                translatedText = jsonResponse["content"]?.ToString();
+            }
 
             translatedText = SakuraUtil.FixTranslationEnd(untranslatedText, translatedText);
 

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -441,7 +441,6 @@ namespace SakuraTranslate
 
         private string MakeGalTranslPromptV2_6(string line)
         {
-            string messagesStr = string.Empty;
             var messages = new List<PromptMessage>
                 {
                     new PromptMessage
@@ -473,26 +472,14 @@ namespace SakuraTranslate
                 }
             }
 
-            if (_useDict == false)
+            messages.Add(new PromptMessage
             {
-                // 如果术语表为空，直接构建翻译指令
-                messages.Add(new PromptMessage
-                {
-                    Role = "user",
-                    Content = $"将下面的日文文本翻译成中文：{line}"
-                });
-            }
-            else
-            {
-                messages.Add(new PromptMessage
-                {
-                    Role = "user",
-                    Content = $"参考以下术语表（可为空，格式为src->dst #备注）：\n{dictStr}\n" +
-                                $"根据上述术语表的对应关系和备注，结合历史剧情和上下文，以流畅的风格将下面的文本从日文翻译成简体中文：{line}"
-                });
-            }
+                Role = "user",
+                Content = $"参考以下术语表（可为空，格式为src->dst #备注）：{(string.IsNullOrEmpty(dictStr) ? string.Empty : "\n" + dictStr)}\n\n" +
+                            $"根据上述术语表的对应关系和备注，结合历史剧情和上下文，以流畅的风格将下面的文本从日文翻译成简体中文：{line}"
+            });
 
-            messagesStr = SerializePromptMessages(messages);
+            var messagesStr = SerializePromptMessages(messages);
             //Console.WriteLine($"提交的prompt: {messagesStr}");
 
             return $"{{" +

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -180,20 +180,7 @@ namespace SakuraTranslate
             JObject jsonResponse = JObject.Parse(responseText);
             string translatedText = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString();
 
-
-            //历史遗留
-            //if (translatedLine.EndsWith("<|im_end|>"))
-            //{
-            //    translatedLine = translatedLine.Substring(0, translatedLine.Length - "<|im_end|>".Length);
-            //}
-            //if (translatedLine.EndsWith("。") && !line.Trim().EndsWith("。"))
-            //{
-            //    translatedLine = translatedLine.Substring(0, translatedLine.Length - "。".Length);
-            //}
-            //if (translatedLine.EndsWith("。」") && !line.Trim().EndsWith("。」"))
-            //{
-            //    translatedLine = translatedLine.Substring(0, translatedLine.Length - "。」".Length) + "」";
-            //}
+            translatedText = SakuraUtil.FixTranslationEnd(untranslatedText, translatedText);
 
             // 提交翻译文本
             context.Complete(translatedText);

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -12,8 +12,8 @@ using System.Xml.Linq;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 using XUnity.AutoTranslator.Plugin.Core.Utilities;
 
-[assembly: AssemblyVersion("0.3.4")]
-[assembly: AssemblyFileVersion("0.3.4")]
+[assembly: AssemblyVersion("0.3.5")]
+[assembly: AssemblyFileVersion("0.3.5")]
 
 namespace SakuraTranslate
 {

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -42,7 +42,7 @@ namespace SakuraTranslate
 
         public void Initialize(IInitializationContext context)
         {
-            _endpoint = context.GetOrCreateSetting<string>("Sakura", "Endpoint", "http://127.0.0.1:5000/v1/chat/completions");
+            _endpoint = context.GetOrCreateSetting<string>("Sakura", "Endpoint", "http://127.0.0.1:8080/v1/chat/completions");
             _modelName = context.GetOrCreateSetting<string>("Sakura", "ModelName", "Sakura");
             _modelVersion = context.GetOrCreateSetting<string>("Sakura", "ModelVersion", "1.0");
             _modelType = GetTranslationModel(_modelName, _modelVersion);

--- a/SakuraTranslator/SakuraUtil.cs
+++ b/SakuraTranslator/SakuraUtil.cs
@@ -1,0 +1,19 @@
+﻿namespace SakuraTranslate
+{
+    public static class SakuraUtil
+    {
+        public static string FixTranslationEnd(string original, string translation)
+        {
+            if (translation.EndsWith("。") && !original.EndsWith("。"))
+            {
+                translation = translation.Substring(0, translation.Length - "。".Length);
+            }
+            if (translation.EndsWith("。」") && !original.EndsWith("。」"))
+            {
+                translation = translation.Substring(0, translation.Length - "。」".Length) + "」";
+            }
+
+            return translation;
+        }
+    }
+}

--- a/SakuraTranslator/TranslationModel.cs
+++ b/SakuraTranslator/TranslationModel.cs
@@ -47,5 +47,10 @@ namespace SakuraTranslate
                     return TranslationModel.SakuraV1_0;
             }
         }
+
+        private static bool IsOpenAIEndpoint(TranslationModel model)
+        {
+            return !(model == TranslationModel.SakuraV0_8 || model == TranslationModel.SakuraV0_9);
+        }
     }
 }


### PR DESCRIPTION
### 变更
- 更改默认端口为8080
- 去除`MakeSakuraPromptV1_0`函数中对`_useDict`的冗余检查
- 更改`MakeGalTranslPromptV2_6`中的prompt构造方式，通过GalTransl-v5.8.1抓包确定，在字典为空时GalTransl v2.6模型不会更换prompt（详见下图）
- 添加`SakuraUtil.FixTranslationEnd`在原句无句号时去除句尾句号
- 添加`IsOpenAIEndpoint`，在使用Sakura 0.8/0.9时，通过`jsonResponse["content"]?.ToString()`获取completion api的翻译结果
- 更新README中的GalTransl链接、完整配置示例使用动态字典（仅发送匹配原句中字典部分）、添加模型使用的`Endpoint`示例；可以考虑同步更新wiki中部署流程部分
- 更改版本号为`0.3.5`

#### GalTransl有字典
![image](https://github.com/user-attachments/assets/5da72d2f-5682-4b0a-9a94-f209e08ab62c)
#### GalTransl无字典
![image](https://github.com/user-attachments/assets/bc4c37da-2c84-408e-849a-787d2e7b06be)
