### PR TITLE
修复Sakura 1.0非完全字典构造，移除Newtonsoft.Json依赖

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Sakura 0.10/1.0和GalTransl模型需要将`Endpoint`设置为chat completions ap
 ### 字典
 #### 字典配置项
 - `UseDict`默认为`False`，设置为`True`才会启用字典功能
-- `DictMode`默认为`Full`，为`Full`时传递整个字典，为`Partial`或其他时，传递当前翻译句子包含的字典部分
+- `DictMode`默认为`Partial`，为`Full`时传递整个字典，为`Partial`或其他时，传递当前翻译句子包含的字典部分
 - `Dict`默认为空字符串
 #### 字典配置（Dict）
 - 必须为空或合法的Json格式，解析失败将会视为空

--- a/SakuraTranslator/SakuraTranslate.csproj
+++ b/SakuraTranslator/SakuraTranslate.csproj
@@ -31,9 +31,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net35\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web.Extensions" />

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -398,7 +398,7 @@ namespace SakuraTranslate
                 }
             }
 
-            if (_useDict == false)
+            if (_useDict == false || string.IsNullOrEmpty(dictStr))
             {
                 // 如果术语表为空，直接构建翻译指令
                 messages.Add(new PromptMessage

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -10,8 +10,8 @@ using System.Text;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 using XUnity.AutoTranslator.Plugin.Core.Utilities;
 
-[assembly: AssemblyVersion("0.3.5")]
-[assembly: AssemblyFileVersion("0.3.5")]
+[assembly: AssemblyVersion("0.3.6")]
+[assembly: AssemblyFileVersion("0.3.6")]
 
 namespace SakuraTranslate
 {

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -56,7 +56,7 @@ namespace SakuraTranslate
             {
                 _useDict = false;
             }
-            _dictMode = context.GetOrCreateSetting<string>("Sakura", "DictMode", "Full");
+            _dictMode = context.GetOrCreateSetting<string>("Sakura", "DictMode", "Partial");
             var dictStr = context.GetOrCreateSetting<string>("Sakura", "Dict", string.Empty);
             if (!string.IsNullOrEmpty(dictStr))
             {

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -1,5 +1,4 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+﻿using SimpleJSON;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
-using System.Xml.Linq;
 using XUnity.AutoTranslator.Plugin.Core.Endpoints;
 using XUnity.AutoTranslator.Plugin.Core.Utilities;
 
@@ -65,12 +63,12 @@ namespace SakuraTranslate
                 try
                 {
                     _dict = new Dictionary<string, List<string>>();
-                    JObject dictJObj = JsonConvert.DeserializeObject(dictStr) as JObject;
+                    var dictJObj = JSON.Parse(dictStr);
                     foreach (var item in dictJObj)
                     {
                         try
                         {
-                            var vArr = JArray.Parse(item.Value.ToString());
+                            var vArr = JSON.Parse(item.Value.ToString()).AsArray;
                             List<string> vList;
                             if (vArr.Count <= 0)
                             {
@@ -78,17 +76,17 @@ namespace SakuraTranslate
                             }
                             else if (vArr.Count == 1)
                             {
-                                vList = new List<string> { vArr[0].ToString(), string.Empty };
+                                vList = new List<string> { vArr[0].ToString().Trim('\"'), string.Empty };
                             }
                             else
                             {
-                                vList = new List<string> { vArr[0].ToString(), vArr[1].ToString() };
+                                vList = new List<string> { vArr[0].ToString().Trim('\"'), vArr[1].ToString().Trim('\"') };
                             }
-                            _dict.Add(item.Key, vList);
+                            _dict.Add(item.Key.Trim('\"'), vList);
                         }
                         catch
                         {
-                            _dict.Add(item.Key, new List<string> { item.Value.ToString(), string.Empty });
+                            _dict.Add(item.Key.Trim('\"'), new List<string> { item.Value.ToString().Trim('\"'), string.Empty });
                         }
                     }
                     if (_dict.Count == 0)
@@ -177,15 +175,15 @@ namespace SakuraTranslate
             //var endIndex = responseText.IndexOf(",", startIndex);
             //var translatedText = responseText.Substring(startIndex, endIndex - startIndex);
 
-            JObject jsonResponse = JObject.Parse(responseText);
+            var jsonResponse = JSON.Parse(responseText);
             string translatedText;
             if (IsOpenAIEndpoint(_modelType))
             {
-                translatedText = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString();
+                translatedText = jsonResponse["choices"]?[0]?["message"]?["content"]?.ToString().Trim('\"');
             }
             else
             {
-                translatedText = jsonResponse["content"]?.ToString();
+                translatedText = jsonResponse["content"]?.ToString().Trim('\"');
             }
 
             translatedText = SakuraUtil.FixTranslationEnd(untranslatedText, translatedText);

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -58,7 +58,12 @@ namespace SakuraTranslate
             }
             _dictMode = context.GetOrCreateSetting<string>("Sakura", "DictMode", "Partial");
             var dictStr = context.GetOrCreateSetting<string>("Sakura", "Dict", string.Empty);
-            if (!string.IsNullOrEmpty(dictStr))
+            if (string.IsNullOrEmpty(dictStr))
+            {
+                _useDict = false;
+                _fullDictStr = string.Empty;
+            }
+            else
             {
                 try
                 {
@@ -378,7 +383,7 @@ namespace SakuraTranslate
             {
                 dictStr = string.Empty;
             }
-            if (_dictMode == "Full")
+            else if (_dictMode == "Full")
             {
                 dictStr = _fullDictStr;
             }

--- a/SakuraTranslator/SakuraTranslateEndpoint.cs
+++ b/SakuraTranslator/SakuraTranslateEndpoint.cs
@@ -191,6 +191,7 @@ namespace SakuraTranslate
                 translatedText = jsonResponse["content"]?.ToString().Trim('\"');
             }
 
+            translatedText = SakuraUtil.UnescapeTranslation(untranslatedText, translatedText);
             translatedText = SakuraUtil.FixTranslationEnd(untranslatedText, translatedText);
 
             // 提交翻译文本

--- a/SakuraTranslator/SakuraUtil.cs
+++ b/SakuraTranslator/SakuraUtil.cs
@@ -15,5 +15,23 @@
 
             return translation;
         }
+
+        public static string UnescapeTranslation(string original, string translation)
+        {
+            if (!original.Contains("\\r"))
+            {
+                translation = translation.Replace("\\r", "\r");
+            }
+            if (!original.Contains("\\n"))
+            {
+                translation = translation.Replace("\\n", "\n");
+            }
+            if (!original.Contains("\\t"))
+            {
+                translation = translation.Replace("\\t", "\t");
+            }
+
+            return translation;
+        }
     }
 }

--- a/SakuraTranslator/packages.config
+++ b/SakuraTranslator/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net35" />
   <package id="XUnity.AutoTranslator.Plugin.Core" version="4.7.0" targetFramework="net35" />
   <package id="XUnity.AutoTranslator.Plugin.ExtProtocol" version="1.0.0" targetFramework="net35" />
   <package id="XUnity.Common" version="1.0.0" targetFramework="net35" />


### PR DESCRIPTION
### 变更
- Sakura 1.0补充判断条件`dictStr`为空时直接构造prompt
- 去除`Newtonsoft.Json`依赖，更改为`AutoTranslator`自带的`SimpleJSON`，可解决部分游戏找不到`Newtonsoft.Json`的问题（如下图）
- 更改默认`DictMode`为`Partial`
- 还原`\r`、`\n`、`\t`（`\\n` -> `\n`）
- 更新版本号为`0.3.6`

### RJ01264730
![image](https://github.com/user-attachments/assets/07ec6a26-8900-4682-91d8-94b13eb89892)
